### PR TITLE
Small Fix in mc.go

### DIFF
--- a/mc.go
+++ b/mc.go
@@ -25,10 +25,10 @@ func connect(prot, dest string) (rv *memcachedClient) {
 	}
 	rv = new(memcachedClient)
 	rv.Conn = conn
-	rv.writer, err = bufio.NewWriterSize(rv.Conn, bufsize)
-	if err != nil {
-		panic("Can't make a buffer")
-	}
+	rv.writer = bufio.NewWriterSize(rv.Conn, bufsize)
+	//if err != nil {
+		//panic("Can't make a buffer")
+	//}
 	rv.hdrBuf = make([]byte, HDR_LEN)
 	return rv
 }


### PR DESCRIPTION
bufio.NewWriterSize returns just the *Writer (no err). just commented out the code after that checking err. Maybe they changed return param in newer version of Go, I am on 1.0.2
