### PR TITLE
TAP connections no longer drain connection pool

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -120,5 +120,10 @@ func (cp *connectionPool) StartTapFeed(args *memcached.TapArguments) (*memcached
 	if err != nil {
 		return nil, err
 	}
+
+	// A connection can't be used after TAP; Dont' count it against the
+	// connection pool capacity
+	<-cp.createsem
+
 	return mc.StartTapFeed(*args)
 }


### PR DESCRIPTION
TAP event connections to the couchbase server cannot be reused once they
are exhausted, and are therefore closed when complete. Because these
connections are pulled from the connection pool but are never returned,
an application making periodic TAP streams will eventually exhaust the
connection pool, indefinately blocking the app (by 720h by default).

Capacity of the connection pool is managed by a buffered channel which
acts as a semaphore. Sending on the channel acquires the samephore,
receiving releases it.

To allow TAP connections that do not count against the connection pool
capacity, we simply release the semaphore when creating the stream.
