### PR TITLE
MB-10948: cbq-engine crashes under light load

### DIFF
--- a/pools.go
+++ b/pools.go
@@ -19,7 +19,9 @@ import (
 )
 
 // HTTPClient to use for REST and view operations.
-var HTTPClient = http.DefaultClient
+var MaxIdleConnsPerHost = 256
+var HTTPTransport = &http.Transport{MaxIdleConnsPerHost: MaxIdleConnsPerHost}
+var HTTPClient = &http.Client{Transport: HTTPTransport}
 
 // PoolSize is the size of each connection pool (per host).
 var PoolSize = 4

--- a/views.go
+++ b/views.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -155,10 +156,11 @@ func (b *Bucket) ViewCustom(ddoc, name string, params map[string]interface{},
 			u, res.Status, bod[:l])
 	}
 
-	d := json.NewDecoder(res.Body)
-	if err := d.Decode(vres); err != nil {
-		return err
+	body, err := ioutil.ReadAll(res.Body)
+	if err := json.Unmarshal(body, vres); err != nil {
+		return nil
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
-Limit max number of HTTP client connections to avoid too many
connections
-Decode http response after reading the body. json.Decoder was causing
http connection to be torn down.
