### PR TITLE
Implement Bucket#Flush()

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,7 +29,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"runtime"
 	"strings"
 	"sync"
@@ -720,4 +722,25 @@ func (b *Bucket) WaitForPersistence(k string, cas uint64, deletion bool) error {
 			return ErrTimeout
 		}
 	}
+}
+
+func (b *Bucket) Flush() error {
+	u := *b.pool.client.BaseURL
+	u.User = nil
+	u.Path = "/pools/default/buckets/" + b.Name + "/controller/doFlush"
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return err
+	}
+	maybeAddAuth(req, b.pool.client.ah)
+	res, err := HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		bod, _ := ioutil.ReadAll(io.LimitReader(res.Body, 512))
+		return fmt.Errorf("HTTP error %v deleting %q: %s", res.Status, u.String(), bod)
+	}
+	return nil
 }


### PR DESCRIPTION
Due to the problems mentioned in #16, I've decided to give up on programmatically deleting/creating buckets for now, and instead implement the Flush() method to help with the integration tests I'm writing. It's not quite the same as it's my understanding that flush does not remove design documents, but it's better than nothing.

Please let me know if you'd like this functionality and what changes I should make to my patch.
