### PR TITLE
Add ErrKeyNotFound error for Get* functions to return

### DIFF
--- a/client.go
+++ b/client.go
@@ -387,6 +387,9 @@ func (w WriteOptions) String() string {
 // Error returned from Write with AddOnly flag, when key already exists in the bucket.
 var ErrKeyExists = errors.New("key exists")
 
+// Error returned from Get, when key does not exist in the bucket.
+var ErrKeyNotFound = errors.New("key not found")
+
 // General-purpose value setter.
 //
 // The Set, Add and Delete methods are just wrappers around this.  The
@@ -543,6 +546,11 @@ func (b *Bucket) GetsRaw(k string) (data []byte, flags int,
 		data = res.Body
 		return nil
 	})
+
+	if gomemcached.IsNotFound(err) {
+		err = ErrKeyNotFound
+	}
+
 	return
 }
 


### PR DESCRIPTION
When users use Get*() functions, it is not easy for users to determine if the error is caused from non-existent key. I had to manually read code and find `gomemcached.IsNotFound` method.

Since it does not exist in the `couchbase` package and there is `ErrKeyExists` that serves as a similar function, I've added `ErrKeyNotFound` error to the API.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/couchbase/go-couchbase/39)

<!-- Reviewable:end -->
