### PR TITLE
Paths parsed from response JSON are unescaped before use, this handle…

### DIFF
--- a/pools.go
+++ b/pools.go
@@ -291,6 +291,9 @@ func queryRestAPI(
 	out interface{}) error {
 	u := *baseURL
 	u.User = nil
+	if unescaped, err := url.QueryUnescape(path); err == nil {
+		path = unescaped
+	}
 	if q := strings.Index(path, "?"); q > 0 {
 		u.Path = path[:q]
 		u.RawQuery = path[q+1:]


### PR DESCRIPTION
…s the case where a CBS bucket contains a '%' character. In this case CBS will escape it to %25 when returning bucket URL's, if these are used unchanged the connections will fail with a 404 error. This was originally described in sync_gateway ticket #691  https://github.com/couchbase/sync_gateway/issues/691