### PR TITLE
Modified go get README because new URL doesn't work

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ don't bang on all one node to do all the work.
 
 ## Install
 
-    go get github.com/couchbase/go-couchbase
+    go get github.com/couchbaselabs/go-couchbase
 
 ## Example
 


### PR DESCRIPTION
I've got that weird error when I use github.com/couchbase/go-couchbase as couchbase package:
```shell
github.com/couchbase/go-couchbase/conn_pool.go:56: conn.SetKeepAliveOptions undefined (type *memcached.Client has no field or method SetKeepAliveOptions)
```
I am using now github.com/couchbaselabs/go-couchbase in all my projects and it works better.

Let me now what you think