### PR TITLE
avoid panic when using keep alive settings and the connection fails

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -53,13 +53,14 @@ var ConnPoolCallback func(host string, source string, start time.Time, err error
 func defaultMkConn(host string, ah AuthHandler) (*memcached.Client, error) {
 	conn, err := memcached.Connect("tcp", host)
 
+	if err != nil {
+		return nil, err
+	}
+
 	if TCPKeepalive == true {
 		conn.SetKeepAliveOptions(time.Duration(TCPKeepaliveInterval) * time.Second)
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	if gah, ok := ah.(GenericMcdAuthHandler); ok {
 		err = gah.AuthenticateMemcachedConn(host, conn)
 		if err != nil {


### PR DESCRIPTION
I know this should be done Via Gerrit, but I dont have the patience.

So this can be treated as a notification, and then close the PR.

This PR avoids the following panic....

````
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x4163542]

goroutine 2293 [running]:
third_party/github.com/couchbase/gomemcached/client.(*Client).SetKeepAliveOptions(0x0, 0x6fc23ac00)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/gomemcached/client/mc.go:46 +0xa2
third_party/github.com/couchbase/go-couchbase.defaultMkConn(0xc20810e3e0, 0x1b, 0x4913e20, 0xc20801ee80, 0x4907100, 0x0, 0x0)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/conn_pool.go:57 +0xbe
third_party/github.com/couchbase/go-couchbase.(*connectionPool).GetWithTimeout(0xc20802c700, 0x3b9aca00, 0x0, 0x0, 0x0)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/conn_pool.go:152 +0x635
third_party/github.com/couchbase/go-couchbase.(*connectionPool).Get(0xc20802c700, 0xc2080d4bc0, 0x0, 0x0)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/conn_pool.go:165 +0x46
third_party/github.com/couchbase/go-couchbase.Bucket.getConnectionToVBucket(0x0, 0xc2080d4bc0, 0x4, 0xc208032120, 0x6, 0x6, 0x46ff368, 0x0, 0xc2080d4ba8, 0x7, ...)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/pools.go:310 +0x416
third_party/github.com/couchbase/go-couchbase.func·001(0x0, 0x0, 0x0)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/client.go:99 +0xa7
third_party/github.com/couchbase/go-couchbase.(*Bucket).Do(0xc20803eea0, 0x44d7a50, 0xa, 0xc208201ec0, 0x0, 0x0)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/client.go:111 +0x30c
third_party/github.com/couchbase/go-couchbase.(*Bucket).GetsRaw(0xc20803eea0, 0x44d7a50, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/client.go:629 +0x1e1
third_party/github.com/couchbase/go-couchbase.(*Bucket).GetRaw(0xc20803eea0, 0x44d7a50, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/dan.mullineux/prj/dm/wrk/dev/src/third_party/github.com/couchbase/go-couchbase/client.go:656 +0x72
````