### PR TITLE
fix strings.Replace call arguments

### DIFF
--- a/tools/view2go/view2go.go
+++ b/tools/view2go/view2go.go
@@ -51,5 +51,5 @@ func main() {
 	err = json.Indent(buf, []byte(j), "", "  ")
 
 	fmt.Printf("const %s = `%s`\n", *objName,
-		strings.Replace(buf.String(), "`", "` + \"`\" + `", 0))
+		strings.Replace(buf.String(), "`", "` + \"`\" + `", -1))
 }


### PR DESCRIPTION
strings.Replace call with n=0 argument makes no sense
as it will do nothing. Probably -1 is intended.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>